### PR TITLE
exerciseページの「解答を表示」ボタンが初回では動作しないバグを修正

### DIFF
--- a/static/exercise.js
+++ b/static/exercise.js
@@ -10,3 +10,7 @@ document
       this.textContent = "解答を表示";
     }
   });
+document.addEventListener("DOMContentLoaded", function() {
+  const answer = document.getElementById("answer-text");
+  answer.style.display = "none";
+});


### PR DESCRIPTION
exerciseページにある「解答を表示」ボタンが初回では動作せず、2回目以降でのみ動作するバグを修正しました。